### PR TITLE
fix: remove consent/cookie tokens out of dom to prevent brave/EasyList from finding consent banner

### DIFF
--- a/src/components/global/ConsentBanner/ConsentBanner.be.spec.ts
+++ b/src/components/global/ConsentBanner/ConsentBanner.be.spec.ts
@@ -44,7 +44,7 @@ test.describe('Consent Banner', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
 
     await expect(banner)
       .toBeVisible();
@@ -67,7 +67,7 @@ test.describe('Consent Banner', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
 
     await expect(banner)
       .not.toBeVisible();
@@ -81,7 +81,7 @@ test.describe('Consent Banner', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
     const acceptAll = await banner.getByText('Alle zulassen');
 
     await acceptAll.click();
@@ -116,7 +116,7 @@ test.describe('Consent Banner', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
     const acceptAll = await banner.getByText('Alle ablehnen');
 
     await acceptAll.click();
@@ -150,7 +150,7 @@ test.describe('Consent Banner', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
     const link = banner.getByText('Datenschutzrichtlinien');
 
     await expect(link)
@@ -164,7 +164,7 @@ test.describe('Consent Banner', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
     const link = banner.getByText('Datenschutzrichtlinien');
 
     await page.keyboard.press('Tab');
@@ -183,7 +183,7 @@ test.describe('Consent Banner', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
     const overlay = await page.getByTestId('consent-overlay');
     const overlayButton = await banner.getByText('Auswahl anpassen');
 

--- a/src/components/global/ConsentBanner/ConsentBanner.tsx
+++ b/src/components/global/ConsentBanner/ConsentBanner.tsx
@@ -3,7 +3,11 @@
 import React, {
   useEffect, useRef, useState,
 } from 'react';
-import styles from '@/components/global/ConsentBanner/ConsentBanner.module.scss';
+// Styles use a deliberately keyword-free filename and class names. Brave and
+// EasyList-Cookie cosmetic filters auto-hide elements whose class/id contains
+// "consent"/"cookie"/"banner", which previously hid this dialog while leaving
+// the JS scroll lock engaged. Keep these identifiers free of those tokens.
+import styles from '@/components/global/ConsentBanner/Pb7q2x.module.scss';
 import { InterfaceConsentBanner } from '@/payload-types';
 import { SafeHtml } from '@/components/base/SafeHtml/SafeHtml';
 import { rteToHtml } from '@/utilities/rteToHtml';
@@ -199,17 +203,17 @@ export const ConsentBanner = ({
 
   return (
     <dialog
-      aria-labelledby='consent-banner-title'
-      data-testid='consent-banner'
+      aria-labelledby='pb7q2x-title'
+      data-testid='pb7q2x'
       ref={bannerDialogRef}
-      className={styles.consentBanner}
+      className={styles.root}
       closedby='none'
     >
       <SafeHtml
         as='p'
         className={styles.title}
         html={rteToHtml(title)}
-        id='consent-banner-title'
+        id='pb7q2x-title'
       />
       <SafeHtml
         as='p'

--- a/src/components/global/ConsentBanner/Pb7q2x.module.scss
+++ b/src/components/global/ConsentBanner/Pb7q2x.module.scss
@@ -4,7 +4,11 @@
 @use "../../../styles/utilities/mediaqueries" as *;
 @use "../../../styles/utilities/utilities" as *;
 
-.consentBanner {
+// Class names here are intentionally obfuscated (no "consent"/"cookie"/"banner").
+// Brave and EasyList-Cookie cosmetic filters auto-hide elements whose
+// class/id matches those keywords, which would hide the dialog while leaving the
+// JS scroll lock active. Keep these names keyword-free.
+.root {
   --content-max-width: 1000;
 
   border: none;
@@ -22,7 +26,7 @@
   z-index: 998;
 
   *:focus-visible {
-    anchor-name: --focus-anchor-consent-banner;
+    anchor-name: --focus-anchor-pb7q2x;
     outline: 0;
   }
 
@@ -31,7 +35,7 @@
 
     --flying-focus-border-color: var(--border-primary);
 
-    position-anchor: --focus-anchor-consent-banner;
+    position-anchor: --focus-anchor-pb7q2x;
   }
 
   &[open]:not(.closing) {

--- a/src/components/global/ConsentOverlay/ConsentOverlay.be.spec.ts
+++ b/src/components/global/ConsentOverlay/ConsentOverlay.be.spec.ts
@@ -43,7 +43,7 @@ test.describe('Consent Overlay', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
     const overlay = await page.getByTestId('consent-overlay');
     const overlayButton = await banner.getByText('Auswahl anpassen');
     const close = overlay.getByTestId('consent-overlay-close');
@@ -61,7 +61,7 @@ test.describe('Consent Overlay', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
     const overlay = await page.getByTestId('consent-overlay');
     const overlayButton = await banner.getByText('Auswahl anpassen');
     const close = overlay.getByTestId('consent-overlay-close');
@@ -86,7 +86,7 @@ test.describe('Consent Overlay', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
     const overlayButton = await banner.getByText('Auswahl anpassen');
 
     await overlayButton.click();
@@ -123,7 +123,7 @@ test.describe('Consent Overlay', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
     const overlayButton = await banner.getByText('Auswahl anpassen');
 
     await overlayButton.click();
@@ -168,7 +168,7 @@ test.describe('Consent Overlay', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
     const overlay = await page.getByTestId('consent-overlay');
     const overlayButton = await banner.getByText('Auswahl anpassen');
     const close = overlay.getByTestId('consent-overlay-close');
@@ -187,7 +187,7 @@ test.describe('Consent Overlay', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = await page.getByTestId('consent-banner');
+    const banner = await page.getByTestId('pb7q2x');
     const overlay = await page.getByTestId('consent-overlay');
     const acceptAll = await banner.getByText('Alle zulassen');
 

--- a/src/components/helpers/tracking.be.spec.ts
+++ b/src/components/helpers/tracking.be.spec.ts
@@ -112,7 +112,7 @@ test.describe('Tracking', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    await expect(page.getByTestId('consent-banner'))
+    await expect(page.getByTestId('pb7q2x'))
       .toBeVisible();
 
     await sleep(10_000);
@@ -140,7 +140,7 @@ test.describe('Tracking', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = page.getByTestId('consent-banner');
+    const banner = page.getByTestId('pb7q2x');
 
     await banner.getByText('Alle ablehnen')
       .click();
@@ -172,7 +172,7 @@ test.describe('Tracking', () => {
     await page.waitForLoadState('networkidle');
     await page.waitForLoadState('domcontentloaded');
 
-    const banner = page.getByTestId('consent-banner');
+    const banner = page.getByTestId('pb7q2x');
 
     await banner.getByText('Alle zulassen')
       .click();


### PR DESCRIPTION
closes #1211 